### PR TITLE
allow updating useFormInput values using contoller.set 

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,6 +1,5 @@
-
 # When any change is pushed on master, it triggers a beta
-# version release with the @next tag 
+# version release with the @next tag
 #
 # When a tag is published, it triggers the release flow,
 # which takes the version which is released and converts
@@ -10,46 +9,45 @@ name: Process master branch updates
 on:
   push:
     branches:
-      - master
+      - v2.0.x
 
 jobs:
   prepare-master:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: v2.0.x
       - run: |
           git config user.name bhoos-devops
           git config user.email devops@bhoos.com
+          echo -e "github.com\n  login $GITHUB_TOKEN" >> ~/.netrc
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@bhoos'
+          node-version: "14.x"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@bhoos"
 
       - name: Install Dependencies and publish packages
         run: |
           yarn
-          yarn version --patch
-          yarn publish . --tag next
+          yarn patch
           version=$(node -p "require('./package.json').version")
-          echo "RELEASE_VERSION=v${version}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${version}" >> $GITHUB_ENV
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
       - name: Build Changelog
         id: github_release
         uses: mikepenz/release-changelog-builder-action@v1
-        with:
-          configuration: "workflow_config/config.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release for moving to production
-        uses: ncipollo/release-action@v1
+        uses: actions/create-release@v1
         with:
-          tag: ${{ env.RELEASE_VERSION }}
-          name: Release ${{ env.RELEASE_VERSION }}
-          commit: master
+          tag_name: ${{ env.RELEASE_VERSION }}
+          release_name: Release v${{ env.RELEASE_VERSION }}
           body: ${{steps.github_release.outputs.changelog}}
           draft: true
           prerelease: false

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,9 +33,9 @@ jobs:
           yarn
           yarn patch
           version=$(node -p "require('./package.json').version")
-          echo "RELEASE_VERSION=${version}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=v${version}" >> $GITHUB_ENV
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Changelog
         id: github_release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bhoos/react-kit",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "Bhoos React Library",
   "main": "dist/index.js",
   "module": "es6/index.js",

--- a/src/form/hooks.ts
+++ b/src/form/hooks.ts
@@ -27,15 +27,21 @@ export function useFormValueOf<T extends GenericState>(controller: FormControlle
   return value;
 }
 
-export function useFormInput<E=string>(name: string, extractValue?: (evt: E) => string): [string, (evt: E) => void] {
+export function useFormInput<E = string>(name: string, extractValue?: (evt: E) => string): [string, (evt: E) => void] {
   const controller = useContext(FormContext);
   const [value, setValue] = useState(controller.getInput(name));
 
-  return [value, (newValue: E) => {
+  const updateValue = (newValue: E) => {
     const k = extractValue ? extractValue(newValue) : newValue as never as string;
     controller.setInput(name, k);
     setValue(k);
-  }];
+  };
+
+  useEffect(() => {
+    return controller.listen(name, updateValue);
+  }, [controller, name]);
+
+  return [value, updateValue];
 }
 
 export function useFormController<T extends GenericState>(

--- a/src/form/hooks.ts
+++ b/src/form/hooks.ts
@@ -38,6 +38,7 @@ export function useFormInput<E = string>(name: string, extractValue?: (evt: E) =
   };
 
   useEffect(() => {
+    // Adding listener to allow updating value using controller.set function
     return controller.listen(name, updateValue);
   }, [controller, name]);
 


### PR DESCRIPTION
## Proposed Changes
- Allow updating useFormInput values using contoller.set so that it can be updated without submitting the form if needed. Example use case: A user is editing a value through a form but the value itself is constantly changing in the server! in that case, we need a way to reflect the changes in the UI.
- Update workflow to support deployments in new branch